### PR TITLE
Fixed the issue of reading pseudo elements followed by a comma and next element

### DIFF
--- a/ExCSS.Tests/SelectorFixture.cs
+++ b/ExCSS.Tests/SelectorFixture.cs
@@ -559,5 +559,32 @@ filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#1e5799',endCo
             Assert.AreEqual(css, results.ToString());
             Assert.AreEqual("*display", results.StyleRules.Single().Declarations.Single().Name);
         }
+
+        [Test]
+        public void Parser_Reads_PseudoElement_Followed_By_Comma_And_Next_Element()
+        {
+            var css = @"#fileData::-ms-browse,input#fileData{border:solid 1px gray;}";
+            var results = new Parser().Parse(css);
+            Assert.That(results.Errors.Count == 0);
+            Assert.AreEqual(css, results.ToString());
+            Assert.IsTrue(results.StyleRules.Single().Selector is AggregateSelectorList);
+            Assert.AreEqual(2, ((AggregateSelectorList)results.StyleRules.Single().Selector).Count());
+            Assert.AreEqual("#fileData::-ms-browse", ((AggregateSelectorList)results.StyleRules.Single().Selector).First().ToString());
+            Assert.AreEqual("input#fileData", ((AggregateSelectorList)results.StyleRules.Single().Selector).Last().ToString());
+        }
+
+        [Test]
+        public void Parser_Reads_PseudoElement_Followed_By_Inner_Element()
+        {
+            var css = @"#fileData::-ms-browse p.myclass,input#fileData{border:solid 1px gray;}";
+            var results = new Parser().Parse(css);
+            Assert.That(results.Errors.Count == 0);
+            Assert.AreEqual(css, results.ToString());
+            Assert.IsTrue(results.StyleRules.Single().Selector is AggregateSelectorList);
+            Assert.AreEqual(2, ((AggregateSelectorList)results.StyleRules.Single().Selector).Count());
+            Assert.AreEqual("#fileData::-ms-browse p.myclass", ((AggregateSelectorList)results.StyleRules.Single().Selector).First().ToString());
+            Assert.AreEqual("input#fileData", ((AggregateSelectorList)results.StyleRules.Single().Selector).Last().ToString());
+        }
+
     }
 }

--- a/ExCSS/Model/Selector/SelectorFactory.cs
+++ b/ExCSS/Model/Selector/SelectorFactory.cs
@@ -350,6 +350,8 @@ namespace ExCSS
                     Insert(SimpleSelector.PseudoElement(data));
                     break;
             }
+
+            _selectorOperation = SelectorOperation.Data;
         }
 
         private void PraseClass(Block token)


### PR DESCRIPTION
I've found an issue in ExCSS parser; it was caused by some pseudo-elements in selector groups or combinators. Once a pseudo-element with double colons (like ::-ms-browse) appears in a selector, the parser is not able to get next selectors properly.

For example, selectors for the following classes were not properly parsed:
#fileData::-ms-browse,input#fileData{border:solid 1px gray;}
#fileData::-ms-browse p.myclass,input#fileData{border:solid 1px gray;}

This update fixes this problem by adding a statement to change the current selector operation:
   _selectorOperation = SelectorOperation.Data;
in the method ParsePseudoElement in the same manner as other parsing methods do it. I suppose this piece of code was forgotten in this method. 
